### PR TITLE
Add Impressum satire page

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Impressum</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <div class="logo">Vucci News</div>
+            <nav>
+                <ul>
+                    <li><a href="index.html">Startseite</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main class="container">
+        <h1>Impressum</h1>
+        <p>Angaben gem&auml;&szlig; &sect; 5 TMG</p>
+        <p>Tobias Wilde-Zahn<br>
+        Vucci News<br>
+        E-Mail: <a href="mailto:info@vucci-news.de">info@vucci-news.de</a></p>
+        <h2>Satire-Projekt</h2>
+        <p>Diese Website ist ein Satireprojekt und dient ausschlie&szlig;lich der Unterhaltung. Alle Inhalte sind frei erfunden und haben keinen realen Hintergrund.</p>
+    </main>
+    <footer>
+        <div class="footer-container">
+            <div class="footer-section">
+                <h4>Über Vucci News</h4>
+                <p>Vucci News ist Ihr spezialisiertes Nachrichtenportal f&uuml;r aktuelle Informationen aus der Feuerwehrwelt und der DIN-Normen-Welt.</p>
+            </div>
+            <div class="footer-section">
+                <h4>Links</h4>
+                <ul>
+                    <li><a href="impressum.html">Impressum</a></li>
+                    <li><a href="#">Datenschutz</a></li>
+                </ul>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
             <div class="footer-section">
                 <h4>Links</h4>
                 <ul>
-                    <li><a href="#">Impressum</a></li>
+                    <li><a href="impressum.html">Impressum</a></li>
                     <li><a href="#">Datenschutz</a></li>
                     <li><a href="#">Kontakt</a></li>
                     <li><a href="#">Werben bei uns</a></li>


### PR DESCRIPTION
## Summary
- add a new `impressum.html` page stating Tobias Wilde-Zahn as contact and clarifying the project is satire
- link the new page from the index footer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f152dec908327a5edf025be559902