### PR TITLE
Add legal and contact pages

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Impressum</title>
+    <title>Datenschutz</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -18,19 +18,16 @@
         </div>
     </header>
     <main class="container">
-        <h1>Impressum</h1>
-        <p>Angaben gem&auml;&szlig; &sect; 5 TMG</p>
-        <p>Tobias Wilde-Zahn<br>
-        Vucci News<br>
-        E-Mail: <a href="mailto:info@vucci-news.de">info@vucci-news.de</a></p>
-        <h2>Satire-Projekt</h2>
-        <p>Diese Website ist ein Satireprojekt und dient ausschlie&szlig;lich der Unterhaltung. Alle Inhalte sind frei erfunden und haben keinen realen Hintergrund.</p>
+        <h1>Datenschutzerkl&auml;rung</h1>
+        <p>Der Schutz Ihrer Daten ist uns wichtig. Diese Seite speichert keine personenbezogenen Daten und verwendet keine Tracking-Tools.</p>
+        <p>Alle eventuell anfallenden Logfiles werden ausschlie&szlig;lich zur technischen &Uuml;berwachung verwendet und nach 30 Tagen gel&ouml;scht.</p>
+        <p>Bei Fragen zum Datenschutz k&ouml;nnen Sie uns unter <a href="mailto:info@vucci-news.de">info@vucci-news.de</a> erreichen.</p>
         <p><a href="index.html" class="back-link">Zur&uuml;ck zur Startseite</a></p>
     </main>
     <footer>
         <div class="footer-container">
             <div class="footer-section">
-                <h4>Über Vucci News</h4>
+                <h4>&Uuml;ber Vucci News</h4>
                 <p>Vucci News ist Ihr spezialisiertes Nachrichtenportal f&uuml;r aktuelle Informationen aus der Feuerwehrwelt und der DIN-Normen-Welt.</p>
             </div>
             <div class="footer-section">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             <div class="logo">Vucci News</div>
             <nav>
                 <ul>
-                    <li><a href="#">Startseite</a></li>
+                    <li><a href="index.html">Startseite</a></li>
                     <li><a href="#feuerwehr">Feuerwehr</a></li>
                     <li><a href="#din">DIN Normen</a></li>
                     <li><a href="#politik">Politik</a></li>
@@ -109,9 +109,9 @@
                 <h4>Links</h4>
                 <ul>
                     <li><a href="impressum.html">Impressum</a></li>
-                    <li><a href="#">Datenschutz</a></li>
-                    <li><a href="#">Kontakt</a></li>
-                    <li><a href="#">Werben bei uns</a></li>
+                    <li><a href="datenschutz.html">Datenschutz</a></li>
+                    <li><a href="kontakt.html">Kontakt</a></li>
+                    <li><a href="werben.html">Werben bei uns</a></li>
                 </ul>
             </div>
             <div class="footer-section">

--- a/kontakt.html
+++ b/kontakt.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Impressum</title>
+    <title>Kontakt</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -18,19 +18,19 @@
         </div>
     </header>
     <main class="container">
-        <h1>Impressum</h1>
-        <p>Angaben gem&auml;&szlig; &sect; 5 TMG</p>
-        <p>Tobias Wilde-Zahn<br>
-        Vucci News<br>
-        E-Mail: <a href="mailto:info@vucci-news.de">info@vucci-news.de</a></p>
-        <h2>Satire-Projekt</h2>
-        <p>Diese Website ist ein Satireprojekt und dient ausschlie&szlig;lich der Unterhaltung. Alle Inhalte sind frei erfunden und haben keinen realen Hintergrund.</p>
+        <h1>Kontakt</h1>
+        <p>Sie m&ouml;chten mit uns in Verbindung treten? Nutzen Sie die folgenden Kontaktm&ouml;glichkeiten:</p>
+        <ul>
+            <li>E-Mail: <a href="mailto:info@vucci-news.de">info@vucci-news.de</a></li>
+            <li>Telefon: 01234/56789</li>
+            <li>Adresse: Musterstra&szlig;e 1, 12345 Musterstadt</li>
+        </ul>
         <p><a href="index.html" class="back-link">Zur&uuml;ck zur Startseite</a></p>
     </main>
     <footer>
         <div class="footer-container">
             <div class="footer-section">
-                <h4>Über Vucci News</h4>
+                <h4>&Uuml;ber Vucci News</h4>
                 <p>Vucci News ist Ihr spezialisiertes Nachrichtenportal f&uuml;r aktuelle Informationen aus der Feuerwehrwelt und der DIN-Normen-Welt.</p>
             </div>
             <div class="footer-section">

--- a/werben.html
+++ b/werben.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Impressum</title>
+    <title>Werben bei uns</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -18,19 +18,15 @@
         </div>
     </header>
     <main class="container">
-        <h1>Impressum</h1>
-        <p>Angaben gem&auml;&szlig; &sect; 5 TMG</p>
-        <p>Tobias Wilde-Zahn<br>
-        Vucci News<br>
-        E-Mail: <a href="mailto:info@vucci-news.de">info@vucci-news.de</a></p>
-        <h2>Satire-Projekt</h2>
-        <p>Diese Website ist ein Satireprojekt und dient ausschlie&szlig;lich der Unterhaltung. Alle Inhalte sind frei erfunden und haben keinen realen Hintergrund.</p>
+        <h1>Werben bei Vucci News</h1>
+        <p>M&ouml;chten Sie Ihre Produkte oder Dienstleistungen auf Vucci News pr&auml;sentieren? Wir bieten verschiedene Werbem&ouml;glichkeiten an.</p>
+        <p>Kontaktieren Sie uns f&uuml;r individuelle Angebote unter <a href="mailto:werbung@vucci-news.de">werbung@vucci-news.de</a>.</p>
         <p><a href="index.html" class="back-link">Zur&uuml;ck zur Startseite</a></p>
     </main>
     <footer>
         <div class="footer-container">
             <div class="footer-section">
-                <h4>Über Vucci News</h4>
+                <h4>&Uuml;ber Vucci News</h4>
                 <p>Vucci News ist Ihr spezialisiertes Nachrichtenportal f&uuml;r aktuelle Informationen aus der Feuerwehrwelt und der DIN-Normen-Welt.</p>
             </div>
             <div class="footer-section">


### PR DESCRIPTION
## Summary
- add Datenschutz, Kontakt and Werben pages using existing corporate design
- link new pages from the footer
- update Impressum footer with the new links
- point the Startseite navigation link to `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe07fa4dc8327aa625658b8dcb89c