### PR TITLE
Replace deprecated marquee with CSS animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
     <!-- Breaking News Laufband -->
     <div class="breaking-news">
-        <marquee behavior="scroll" direction="left"><a href="https://www.presseportal.de/blaulicht/pm/116052/5822629#:~:text=Die%20ersten%20Einheiten%20leiteten%20eine%20Brandbek%C3%A4mpfung%20mit%20einem%20Rohr%20im%20Inneren%20des%20Geb%C3%A4udes%20und%20einem%20weiteren%20Rohr%20%C3%BCber%20eine%20Drehleiter%20von%20au%C3%9Fen%20ein" target="_blank">FW-F: Feuer in einer Apartmentanlage für pflegebedürftige Menschen - In der Nacht von Samstag auf Sonntag brach im 4. Obergeschoss einer Pflegeeinrichtung in Frankfurt Schwanheim ein Brand aus. Eine Person wurde leicht verletzt, zahlreiche Bewohner unverletzt evakuiert. Einsatzkräfte löschten den Brand bis 5:00 Uhr. Mehrere Wohneinheiten unbewohnbar, Schaden ca. 400.000 €.</a></marquee>
+        <div class="marquee"><a href="https://www.presseportal.de/blaulicht/pm/116052/5822629#:~:text=Die%20ersten%20Einheiten%20leiteten%20eine%20Brandbek%C3%A4mpfung%20mit%20einem%20Rohr%20im%20Inneren%20des%20Geb%C3%A4udes%20und%20einem%20weiteren%20Rohr%20%C3%BCber%20eine%20Drehleiter%20von%20au%C3%9Fen%20ein" target="_blank">FW-F: Feuer in einer Apartmentanlage für pflegebedürftige Menschen - In der Nacht von Samstag auf Sonntag brach im 4. Obergeschoss einer Pflegeeinrichtung in Frankfurt Schwanheim ein Brand aus. Eine Person wurde leicht verletzt, zahlreiche Bewohner unverletzt evakuiert. Einsatzkräfte löschten den Brand bis 5:00 Uhr. Mehrere Wohneinheiten unbewohnbar, Schaden ca. 400.000 €.</a></div>
     </div>
 
     <main class="container">

--- a/styles.css
+++ b/styles.css
@@ -47,14 +47,20 @@ nav ul li a:hover {
     overflow: hidden;
     position: relative;
 }
-.breaking-news marquee {
+.breaking-news .marquee {
+    display: inline-block;
+    white-space: nowrap;
+    padding-left: 100%;
+    animation: marquee 15s linear infinite;
     font-weight: bold;
     font-size: 1rem;
-    animation: blink 2s step-start 0s infinite;
 }
-@keyframes blink {
-    50% { opacity: 0; }
+
+@keyframes marquee {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-100%); }
 }
+
 .featured {
     margin-top: 20px;
     display: grid;


### PR DESCRIPTION
## Summary
- modernize the breaking news ticker by replacing `<marquee>` with a div
- add CSS animation for scrolling text

## Testing
- `grep -R "<marquee" -n`


------
https://chatgpt.com/codex/tasks/task_e_683fe9902ec08327add44103e8ba32ba